### PR TITLE
Fix spawner config default population

### DIFF
--- a/src/main/java/mcjty/rftoolsutility/modules/spawner/SpawnerConfiguration.java
+++ b/src/main/java/mcjty/rftoolsutility/modules/spawner/SpawnerConfiguration.java
@@ -75,7 +75,7 @@ public class SpawnerConfiguration {
             EntityType<?> type = entry.getValue();
             if (type.getClassification() != EntityClassification.MISC) {
                 RegistryKey<EntityType<?>> key = entry.getKey();
-                ResourceLocation id = key.getRegistryName();
+                ResourceLocation id = key.getLocation();
                 byMod.computeIfAbsent(id.getNamespace(), s -> new ArrayList<>());
                 byMod.get(id.getNamespace()).add(id);
             }


### PR DESCRIPTION
getRegistryName was pulling the parent id minecraft:entity_type for
everything, leading to broken configs and log spam

fixes McJtyMods/McJtyLib#124

config [before](https://gist.github.com/phit/3eee774b170c77895c99d1d9b5b6b9ba#file-old-toml), config [after](https://gist.github.com/phit/3eee774b170c77895c99d1d9b5b6b9ba#file-new-toml)