### PR TITLE
Fix crash on Charged Porter linking (#109)

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,3 +1,6 @@
+1.16-3.1.7:
+- Fixed crash when linking the charged porter on a server
+
 1.16-3.1.6:
 - Big fixes on the crafter. It works much cleaner now, will actually remember recipes and works properly with JEI (instead of only now and then)
 - The matter transmitter and receiver private modes now work correctly even if the receiver and/or transmitter is in another dimension

--- a/src/main/java/mcjty/rftoolsutility/modules/teleporter/blocks/MatterReceiverTileEntity.java
+++ b/src/main/java/mcjty/rftoolsutility/modules/teleporter/blocks/MatterReceiverTileEntity.java
@@ -168,6 +168,7 @@ public class MatterReceiverTileEntity extends TickingTileEntity {
         setChanged();
     }
 
+    // Server side only
     public boolean checkAccess(UUID player) {
         if (!privateAccess) {
             return true;

--- a/src/main/java/mcjty/rftoolsutility/modules/teleporter/items/porter/AdvancedChargedPorterItem.java
+++ b/src/main/java/mcjty/rftoolsutility/modules/teleporter/items/porter/AdvancedChargedPorterItem.java
@@ -41,19 +41,14 @@ public class AdvancedChargedPorterItem extends ChargedPorterItem implements IIte
         for (int i = 0 ; i < MAXTARGETS ; i++) {
             if (!tagCompound.contains("target"+i)) {
                 tagCompound.putInt("target"+i, id);
-                if (world.isClientSide) {
-                    Logging.message(player, "Receiver " + id + " is added to the charged porter.");
-                }
+                Logging.message(player, "Receiver " + id + " is added to the charged porter.");
                 if (!tagCompound.contains("target")) {
                     tagCompound.putInt("target", id);
                 }
                 return;
             }
         }
-
-        if (world.isClientSide) {
-            Logging.message(player, TextFormatting.YELLOW + "Charged porter has no free targets!");
-        }
+        Logging.message(player, TextFormatting.YELLOW + "Charged porter has no free targets!");
     }
 
     @Override


### PR DESCRIPTION
Fixes #109 

Updated ChargedPorterItem teleport and linking handling to all be handled server side.

Added checks at the top of both of those methods, and updated messages to all be sent from serverside.

Tested all the expected messages and behaviours are working as expected for normal and advanced charged porters.