### PR TITLE
Add missing counter and counterplus functionality

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,145 @@
+# Created by https://www.toptal.com/developers/gitignore/api/java,intellij+all,forgegradle,gradle
+# Edit at https://www.toptal.com/developers/gitignore?templates=java,intellij+all,forgegradle,gradle
 
-build*
+### ForgeGradle ###
+# Minecraft client/server files
+run/
+
+### Intellij+all ###
+# Covers JetBrains IDEs: IntelliJ, RubyMine, PhpStorm, AppCode, PyCharm, CLion, Android Studio, WebStorm and Rider
+# Reference: https://intellij-support.jetbrains.com/hc/en-us/articles/206544839
+
+# User-specific stuff
+.idea/**/workspace.xml
+.idea/**/tasks.xml
+.idea/**/usage.statistics.xml
+.idea/**/dictionaries
+.idea/**/shelf
+
+# AWS User-specific
+.idea/**/aws.xml
+
+# Generated files
+.idea/**/contentModel.xml
+
+# Sensitive or high-churn files
+.idea/**/dataSources/
+.idea/**/dataSources.ids
+.idea/**/dataSources.local.xml
+.idea/**/sqlDataSources.xml
+.idea/**/dynamic.xml
+.idea/**/uiDesigner.xml
+.idea/**/dbnavigator.xml
+
+# Gradle
+.idea/**/gradle.xml
+.idea/**/libraries
+
+# Gradle and Maven with auto-import
+# When using Gradle or Maven with auto-import, you should exclude module files,
+# since they will be recreated, and may cause churn.  Uncomment if using
+# auto-import.
+# .idea/artifacts
+# .idea/compiler.xml
+# .idea/jarRepositories.xml
+# .idea/modules.xml
+# .idea/*.iml
+# .idea/modules
+# *.iml
+# *.ipr
+
+# CMake
+cmake-build-*/
+
+# Mongo Explorer plugin
+.idea/**/mongoSettings.xml
+
+# File-based project format
+*.iws
+
+# IntelliJ
+out/
+
+# mpeltonen/sbt-idea plugin
+.idea_modules/
+
+# JIRA plugin
+atlassian-ide-plugin.xml
+
+# Cursive Clojure plugin
+.idea/replstate.xml
+
+# SonarLint plugin
+.idea/sonarlint/
+
+# Crashlytics plugin (for Android Studio and IntelliJ)
+com_crashlytics_export_strings.xml
+crashlytics.properties
+crashlytics-build.properties
+fabric.properties
+
+# Editor-based Rest Client
+.idea/httpRequests
+
+# Android studio 3.1+ serialized cache file
+.idea/caches/build_file_checksums.ser
+
+### Intellij+all Patch ###
+# Ignore everything but code style settings and run configurations
+# that are supposed to be shared within teams.
+
+.idea/*
+
+!.idea/codeStyles
+!.idea/runConfigurations
+
+### Java ###
+# Compiled class file
+*.class
+
+# Log file
+*.log
+
+# BlueJ files
+*.ctxt
+
+# Mobile Tools for Java (J2ME)
+.mtj.tmp/
+
+# Package Files #
+*.jar
+*.war
+*.nar
+*.ear
+*.zip
+*.tar.gz
+*.rar
+
+# virtual machine crash logs, see http://www.java.com/en/download/help/error_hotspot.xml
+hs_err_pid*
+replay_pid*
+
+### Gradle ###
+.gradle
+**/build/
+!src/**/build/
+
+# Ignore Gradle GUI config
+gradle-app.setting
+
+# Avoid ignoring Gradle wrapper jar file (.jar files are usually ignored)
+!gradle-wrapper.jar
+
+# Avoid ignore Gradle wrappper properties
+!gradle-wrapper.properties
+
+# Cache of project
+.gradletasknamecache
+
+# Eclipse Gradle plugin generated files
+# Eclipse Core
+.project
+# JDT-specific (Eclipse Java Development Tools)
+.classpath
+
+# End of https://www.toptal.com/developers/gitignore/api/java,intellij+all,forgegradle,gradle

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,3 +1,8 @@
+1.16-3.1.17:
+ - Add recipes for counter and counterplus screen modules
+ - Reset a counter's counter and current value only when counter value in GUI changes
+ - Add functionality for counter and counterplus screen modules
+
 1.16-3.1.16:
 - Fixed the blindness module recipe
 - Added protection for division by zero in the spawner of the gui

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
 modname=RFToolsUtility
-version=1.16-3.1.16
+version=1.16-3.1.17
 curse_type=release
 projectId=342466
 github_project=McJtyMods/RFToolsPower

--- a/src/generated/resources/data/rftoolsutility/recipes/counter_module.json
+++ b/src/generated/resources/data/rftoolsutility/recipes/counter_module.json
@@ -1,0 +1,25 @@
+{
+  "type": "minecraft:crafting_shaped",
+  "pattern": [
+    " X ",
+    "rir",
+    " Z "
+  ],
+  "key": {
+    "X": {
+      "item": "minecraft:comparator"
+    },
+    "r": {
+      "item": "minecraft:redstone"
+    },
+    "i": {
+      "tag": "forge:ingots/iron"
+    },
+    "Z": {
+      "tag": "forge:dyes/black"
+    }
+  },
+  "result": {
+    "item": "rftoolsutility:counter_module"
+  }
+}

--- a/src/generated/resources/data/rftoolsutility/recipes/counterplus_module.json
+++ b/src/generated/resources/data/rftoolsutility/recipes/counterplus_module.json
@@ -1,0 +1,22 @@
+{
+  "type": "minecraft:crafting_shaped",
+  "pattern": [
+    " o ",
+    "zMz",
+    " o "
+  ],
+  "key": {
+    "z": {
+      "tag": "forge:ingots/gold"
+    },
+    "M": {
+      "item": "rftoolsutility:counter_module"
+    },
+    "o": {
+      "tag": "forge:ender_pearls"
+    }
+  },
+  "result": {
+    "item": "rftoolsutility:counterplus_module"
+  }
+}

--- a/src/main/java/mcjty/rftoolsutility/modules/logic/blocks/CounterTileEntity.java
+++ b/src/main/java/mcjty/rftoolsutility/modules/logic/blocks/CounterTileEntity.java
@@ -72,8 +72,16 @@ public class CounterTileEntity extends GenericTileEntity {
     }
 
     public void setCounter(int counter) {
+        // Perform reset of related values only if counter has changed
+        if(counter != this.counter){
+            // Reset current level
+            this.current = 0;
+
+            //Reset power level
+            support.setRedstoneState(this, 0);
+        }
+
         this.counter = counter;
-        current = 0;
         setChanged();
     }
 
@@ -86,6 +94,7 @@ public class CounterTileEntity extends GenericTileEntity {
         if (level.isClientSide) {
             return;
         }
+
         boolean pulse = (powerLevel > 0) && !prevIn;
         prevIn = powerLevel > 0;
 
@@ -94,8 +103,10 @@ public class CounterTileEntity extends GenericTileEntity {
         if (pulse) {
             current++;
             if (current >= counter) {
-                current = 0;
                 newout = 15;
+
+                // Disallow current value to go higher than counter value
+                current = counter;
             }
 
             setChanged();

--- a/src/main/java/mcjty/rftoolsutility/modules/screen/items/modules/CounterModuleItem.java
+++ b/src/main/java/mcjty/rftoolsutility/modules/screen/items/modules/CounterModuleItem.java
@@ -1,13 +1,18 @@
 package mcjty.rftoolsutility.modules.screen.items.modules;
 
 import mcjty.lib.crafting.INBTPreservingIngredient;
+import mcjty.lib.varia.Logging;
+import mcjty.lib.varia.Tools;
 import mcjty.rftoolsbase.api.screens.IModuleGuiBuilder;
 import mcjty.rftoolsbase.tools.GenericModuleItem;
 import mcjty.lib.varia.ModuleTools;
 import mcjty.rftoolsutility.RFToolsUtility;
+import mcjty.rftoolsutility.modules.logic.blocks.CounterTileEntity;
 import mcjty.rftoolsutility.modules.screen.ScreenConfiguration;
 import mcjty.rftoolsutility.modules.screen.modules.CounterScreenModule;
 import mcjty.rftoolsutility.modules.screen.modulesclient.CounterClientScreenModule;
+import net.minecraft.block.Block;
+import net.minecraft.block.BlockState;
 import net.minecraft.entity.player.PlayerEntity;
 import net.minecraft.item.ItemStack;
 import net.minecraft.item.ItemUseContext;
@@ -86,35 +91,38 @@ public class CounterModuleItem extends GenericModuleItem implements INBTPreservi
         PlayerEntity player = context.getPlayer();
         TileEntity te = world.getBlockEntity(pos);
         CompoundNBT tagCompound = stack.getTag();
+
         if (tagCompound == null) {
             tagCompound = new CompoundNBT();
         }
-        // @todo 1.14
-//        if (te instanceof CounterTileEntity) {
-//            tagCompound.putString("monitordim", world.getDimension().getType().getName().toString());
-//            tagCompound.putInt("monitorx", pos.getX());
-//            tagCompound.putInt("monitory", pos.getY());
-//            tagCompound.putInt("monitorz", pos.getZ());
-//            BlockState state = world.getBlockState(pos);
-//            Block block = state.getBlock();
-//            String name = "<invalid>";
-//            if (block != null && !block.isAir(state, world, pos)) {
-//                name = BlockTools.getReadableName(world, pos);
-//            }
-//            tagCompound.putString("monitorname", name);
-//            if (world.isRemote) {
-//                Logging.message(player, "Counter module is set to block '" + name + "'");
-//            }
-//        } else {
-//            tagCompound.remove("monitordim");
-//            tagCompound.remove("monitorx");
-//            tagCompound.remove("monitory");
-//            tagCompound.remove("monitorz");
-//            tagCompound.remove("monitorname");
-//            if (world.isRemote) {
-//                Logging.message(player, "Counter module is cleared");
-//            }
-//        }
+
+        if (te instanceof CounterTileEntity) {
+            String worldDimension = world.dimension().location().toString();
+            tagCompound.putString("monitordim", worldDimension);
+            tagCompound.putInt("monitorx", pos.getX());
+            tagCompound.putInt("monitory", pos.getY());
+            tagCompound.putInt("monitorz", pos.getZ());
+            BlockState state = world.getBlockState(pos);
+            Block block = state.getBlock();
+            String name = "<invalid>";
+            if (!block.isAir(state, world, pos)) {
+                name = Tools.getReadableName(world, pos);
+            }
+            tagCompound.putString("monitorname", name);
+            if (!world.isClientSide) {
+                Logging.message(player, "Counter module is set to block '" + name + "'");
+            }
+        } else {
+            tagCompound.remove("monitordim");
+            tagCompound.remove("monitorx");
+            tagCompound.remove("monitory");
+            tagCompound.remove("monitorz");
+            tagCompound.remove("monitorname");
+            if (!world.isClientSide) {
+                Logging.message(player, "Counter module is cleared");
+            }
+        }
+
         stack.setTag(tagCompound);
         return ActionResultType.SUCCESS;
     }

--- a/src/main/java/mcjty/rftoolsutility/modules/screen/items/modules/CounterPlusModuleItem.java
+++ b/src/main/java/mcjty/rftoolsutility/modules/screen/items/modules/CounterPlusModuleItem.java
@@ -1,12 +1,17 @@
 package mcjty.rftoolsutility.modules.screen.items.modules;
 
+import mcjty.lib.varia.Logging;
+import mcjty.lib.varia.Tools;
 import mcjty.rftoolsbase.api.screens.IModuleGuiBuilder;
 import mcjty.rftoolsbase.tools.GenericModuleItem;
 import mcjty.lib.varia.ModuleTools;
 import mcjty.rftoolsutility.RFToolsUtility;
+import mcjty.rftoolsutility.modules.logic.blocks.CounterTileEntity;
 import mcjty.rftoolsutility.modules.screen.ScreenConfiguration;
 import mcjty.rftoolsutility.modules.screen.modules.CounterPlusScreenModule;
 import mcjty.rftoolsutility.modules.screen.modulesclient.CounterPlusClientScreenModule;
+import net.minecraft.block.Block;
+import net.minecraft.block.BlockState;
 import net.minecraft.client.util.ITooltipFlag;
 import net.minecraft.entity.player.PlayerEntity;
 import net.minecraft.item.ItemStack;
@@ -107,39 +112,39 @@ public class CounterPlusModuleItem extends GenericModuleItem {
         ItemStack stack = context.getItemInHand();
         World world = context.getLevel();
         BlockPos pos = context.getClickedPos();
-        Direction facing = context.getClickedFace();
         PlayerEntity player = context.getPlayer();
         TileEntity te = world.getBlockEntity(pos);
         CompoundNBT tagCompound = stack.getTag();
+
         if (tagCompound == null) {
             tagCompound = new CompoundNBT();
         }
-        // @todo 1.14
-//        if (te instanceof CounterTileEntity) {
-//            tagCompound.putString("monitordim", world.getDimension().getType().getName().toString());
-//            tagCompound.putInt("monitorx", pos.getX());
-//            tagCompound.putInt("monitory", pos.getY());
-//            tagCompound.putInt("monitorz", pos.getZ());
-//            BlockState state = world.getBlockState(pos);
-//            Block block = state.getBlock();
-//            String name = "<invalid>";
-//            if (block != null && !block.isAir(state, world, pos)) {
-//                name = BlockTools.getReadableName(world, pos);
-//            }
-//            tagCompound.putString("monitorname", name);
-//            if (world.isRemote) {
-//                Logging.message(player, "Counter module is set to block '" + name + "'");
-//            }
-//        } else {
-//            tagCompound.remove("monitordim");
-//            tagCompound.remove("monitorx");
-//            tagCompound.remove("monitory");
-//            tagCompound.remove("monitorz");
-//            tagCompound.remove("monitorname");
-//            if (world.isRemote) {
-//                Logging.message(player, "Counter module is cleared");
-//            }
-//        }
+
+        if (te instanceof CounterTileEntity) {
+            BlockState state = world.getBlockState(pos);
+            Block block = state.getBlock();
+            String name = "<invalid>";
+
+            if (!block.isAir(state, world, pos)) {
+                name = Tools.getReadableName(world, pos);
+            }
+
+            tagCompound.putString("monitorname", name);
+            ModuleTools.setPositionInModule(stack, world.dimension(), pos, name);
+
+            if (world.isClientSide) {
+                Logging.message(player, "Counter module is set to block '" + name + "'");
+            }
+        } else {
+            tagCompound.remove("monitordim");
+            tagCompound.remove("monitorx");
+            tagCompound.remove("monitory");
+            tagCompound.remove("monitorz");
+            tagCompound.remove("monitorname");
+            if (world.isClientSide) {
+                Logging.message(player, "Counter module is cleared");
+            }
+        }
         stack.setTag(tagCompound);
         return ActionResultType.SUCCESS;
     }

--- a/src/main/java/mcjty/rftoolsutility/modules/screen/modules/CounterScreenModule.java
+++ b/src/main/java/mcjty/rftoolsutility/modules/screen/modules/CounterScreenModule.java
@@ -5,6 +5,7 @@ import mcjty.lib.varia.LevelTools;
 import mcjty.rftoolsbase.api.screens.IScreenDataHelper;
 import mcjty.rftoolsbase.api.screens.IScreenModule;
 import mcjty.rftoolsbase.api.screens.data.IModuleDataInteger;
+import mcjty.rftoolsutility.modules.logic.blocks.CounterTileEntity;
 import mcjty.rftoolsutility.modules.screen.ScreenConfiguration;
 import net.minecraft.entity.player.PlayerEntity;
 import net.minecraft.nbt.CompoundNBT;
@@ -32,14 +33,12 @@ public class CounterScreenModule implements IScreenModule<IModuleDataInteger> {
 
         TileEntity te = world.getBlockEntity(coordinate);
 
-        // @todo 1.14
-//        if (!(te instanceof CounterTileEntity)) {
-//            return null;
-//        }
-//
-//        CounterTileEntity counterTileEntity = (CounterTileEntity) te;
-//        return helper.createInteger(counterTileEntity.getCurrent());
-        return null;
+        if (!(te instanceof CounterTileEntity)) {
+            return null;
+        }
+
+        CounterTileEntity counterTileEntity = (CounterTileEntity) te;
+        return helper.createInteger(counterTileEntity.getCurrent());
     }
 
     @Override

--- a/src/main/java/mcjty/rftoolsutility/modules/screen/modulesclient/CounterClientScreenModule.java
+++ b/src/main/java/mcjty/rftoolsutility/modules/screen/modulesclient/CounterClientScreenModule.java
@@ -51,13 +51,13 @@ public class CounterClientScreenModule implements IClientScreenModule<IModuleDat
         }
 
         if (!BlockPosTools.INVALID.equals(coordinate)) {
-            int counter;
+            int current;
             if (screenData != null) {
-                counter = screenData.get();
+                current = screenData.get();
             } else {
-                counter = 0;
+                current = 0;
             }
-            String output = renderHelper.format(String.valueOf(counter), format);
+            String output = renderHelper.format(String.valueOf(current), format);
             renderHelper.renderText(matrixStack, buffer, xoffset, currenty, cntcolor, renderInfo, output);
         } else {
             renderHelper.renderText(matrixStack, buffer, xoffset, currenty, 0xff0000, renderInfo, "<invalid>");


### PR DESCRIPTION
This PR is to address #147.

The counter and counterplus screen module recipies have been added. Also the functionality of those items were uncommented out to allow for them to work and updated to use the `Tools` class rather than the old `BlockTools` class.

There is a change made to the screen module that the value displayed is the `current` value from the counter rather than the `counter` value. I'm unsure of the original intent that the code had in using `counter`, but with using `current` the screen will update to display how many clicks a counter has received.

Additionally, it appears that the `current` value for a counter was 1 based. That was changed to where the value would start at 0 since no pulse would have been sent to the counter.

Finally, a change was added to where the counter will not increase past the value of the `counter` property set by the user. The reasoning for introducing this was due to the fact that at this point, the counter has met it's criteria and has an output of full power level. Pressing the counter more does not change the power. I don't have a full background on the history of this mod, so if this change (found within `CounterTileEntity.java` in the `update()` method) should be reverted, I'll gladly do so.