### PR TITLE
Add a persistent tag to entities spawned by the mob spawner.

### DIFF
--- a/src/main/java/mcjty/rftoolsutility/modules/spawner/blocks/SpawnerTileEntity.java
+++ b/src/main/java/mcjty/rftoolsutility/modules/spawner/blocks/SpawnerTileEntity.java
@@ -280,6 +280,9 @@ public class SpawnerTileEntity extends TickingTileEntity {
             Logging.logError("Fail to spawn mob: " + mobId);
             return;
         }
+		
+        // Add a persistent tag to indicate that the mob came from a RFToolsUtility spawner.
+        entityLiving.getPersistentData().putBoolean("rftoolsutility:spawner", true);
 
         // @todo 1.15
 //        if (entityLiving instanceof EntityDragon) {


### PR DESCRIPTION
Add a persistent tag to entities spawned by the mob spawner. This is the same sort of thing that Pneumaticcraft does and permits custom things to be done to entities spawned by the spawner via KubeJS, for example.