### PR TITLE
More recipe caching

### DIFF
--- a/src/main/java/mcjty/rftoolsutility/modules/crafter/blocks/CrafterBaseTE.java
+++ b/src/main/java/mcjty/rftoolsutility/modules/crafter/blocks/CrafterBaseTE.java
@@ -39,6 +39,7 @@ import net.minecraft.world.inventory.TransientCraftingContainer;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.item.crafting.Ingredient;
 import net.minecraft.world.item.crafting.Recipe;
+import net.minecraft.world.item.crafting.RecipeType;
 import net.minecraft.world.item.crafting.ShapedRecipe;
 import net.minecraft.world.level.block.entity.BlockEntityType;
 import net.minecraft.world.level.block.state.BlockState;
@@ -129,7 +130,9 @@ public class CrafterBaseTE extends TickingTileEntity implements JEIRecipeAccepto
                 }
             }
             if (matchingRecipe == null) {
-                matchingRecipe = CraftingRecipe.findRecipe(level, workInventory);
+                matchingRecipe = level.getRecipeManager()
+                                      .getRecipeFor(RecipeType.CRAFTING, workInventory, level)
+                                      .orElse(null);
             }
             if (matchingRecipe != null) {
                 ItemStack result = BaseRecipe.assemble(matchingRecipe, workInventory, level);

--- a/src/main/java/mcjty/rftoolsutility/modules/crafter/blocks/CrafterBaseTE.java
+++ b/src/main/java/mcjty/rftoolsutility/modules/crafter/blocks/CrafterBaseTE.java
@@ -120,9 +120,19 @@ public class CrafterBaseTE extends TickingTileEntity implements JEIRecipeAccepto
             for (int i = 0; i < 9; i++) {
                 workInventory.setItem(i, items.getStackInSlot(i + SLOT_CRAFTINPUT).copy());
             }
-            Recipe recipe = CraftingRecipe.findRecipe(level, workInventory);
-            if (recipe != null) {
-                ItemStack result = BaseRecipe.assemble(recipe, workInventory, level);
+            Recipe matchingRecipe = null;
+            for (CraftingRecipe recipe : recipes) {
+                Recipe cachedRecipe = recipe.getCachedRecipe(level);
+                if (cachedRecipe != null && cachedRecipe.matches(workInventory, level)) {
+                    matchingRecipe = cachedRecipe;
+                    break;
+                }
+            }
+            if (matchingRecipe == null) {
+                matchingRecipe = CraftingRecipe.findRecipe(level, workInventory);
+            }
+            if (matchingRecipe != null) {
+                ItemStack result = BaseRecipe.assemble(matchingRecipe, workInventory, level);
                 items.setStackInSlot(SLOT_CRAFTOUTPUT, result);
             } else {
                 items.setStackInSlot(SLOT_CRAFTOUTPUT, ItemStack.EMPTY);

--- a/src/main/java/mcjty/rftoolsutility/modules/crafter/data/CraftingRecipe.java
+++ b/src/main/java/mcjty/rftoolsutility/modules/crafter/data/CraftingRecipe.java
@@ -10,7 +10,6 @@ import net.minecraft.world.inventory.CraftingContainer;
 import net.minecraft.world.inventory.TransientCraftingContainer;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.item.crafting.Recipe;
-import net.minecraft.world.item.crafting.RecipeManager;
 import net.minecraft.world.item.crafting.RecipeType;
 import net.minecraft.world.level.Level;
 
@@ -91,13 +90,7 @@ public class CraftingRecipe {
     }
 
     public static Recipe findRecipe(Level world, CraftingContainer inv) {
-        RecipeManager recipeManager = world.getRecipeManager();
-        for (Recipe r : recipeManager.getRecipes()) {
-            if (r != null && RecipeType.CRAFTING.equals(r.getType()) && r.matches(inv, world)) {
-                return r;
-            }
-        }
-        return null;
+        return world.getRecipeManager().getRecipeFor(RecipeType.CRAFTING, inv, world).orElse(null);
     }
 
     public void readFromNBT(CompoundTag tagCompound) {


### PR DESCRIPTION
When playing on the ATM9 modpack I noticed every time I opened a crafter with a bunch of recipes my game froze for a moment. The same happened when a `ClientboundContainerSetContentPacket` was sent (i.e. when shift-clicking and moving multiple items into the crafter at once) although the pause took longer in this case. 
Commit b1ef472ca7dc7ff0b3093e25c2897f0e0d2650f8 fixes the second issue, while 49e53f247e566942f8b3bd65f24920039dc5bbcb the first one